### PR TITLE
Refactor const params

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -2,9 +2,7 @@ use crate::errors::{
     AutomatonScaleError, DaachorseError, DuplicatePatternError, InvalidArgumentError,
     PatternScaleError,
 };
-use crate::{
-    DoubleArrayAhoCorasick, Output, State, FAIL_INVALID, OUTPOS_INVALID, PATTERN_LEN_INVALID,
-};
+use crate::{DoubleArrayAhoCorasick, Output, State, OUTPOS_INVALID, PATTERN_LEN_INVALID};
 
 // The length of each double-array block.
 const BLOCK_LEN: usize = 256;
@@ -16,6 +14,8 @@ const FREE_STATES: usize = BLOCK_LEN * FREE_BLOCKS;
 const STATE_IDX_INVALID: u32 = std::u32::MAX;
 // The maximum ID of a pattern used as an invalid value.
 const PATTERN_ID_INVALID: u32 = std::u32::MAX;
+// The maximum FAIL value.
+const FAIL_MAX: usize = std::u32::MAX as usize >> 8;
 
 struct SparseTrie {
     nodes: Vec<Vec<(u8, usize)>>,
@@ -469,9 +469,9 @@ impl DoubleArrayAhoCorasickBuilder {
                     }
                     fail_idx = next_fail_idx;
                 };
-                if new_fail_idx >= FAIL_INVALID as usize {
+                if new_fail_idx > FAIL_MAX {
                     let e = AutomatonScaleError {
-                        msg: format!("fail_idx must be < {}", FAIL_INVALID),
+                        msg: format!("fail_idx must be < {}", FAIL_MAX),
                     };
                     return Err(DaachorseError::AutomatonScale(e));
                 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -471,7 +471,7 @@ impl DoubleArrayAhoCorasickBuilder {
                 };
                 if new_fail_idx > FAIL_MAX {
                     let e = AutomatonScaleError {
-                        msg: format!("fail_idx must be < {}", FAIL_MAX),
+                        msg: format!("fail_idx must be <= {}", FAIL_MAX),
                     };
                     return Err(DaachorseError::AutomatonScale(e));
                 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -3,9 +3,19 @@ use crate::errors::{
     PatternScaleError,
 };
 use crate::{
-    DoubleArrayAhoCorasick, Output, State, BLOCK_LEN, FAIL_INVALID, FREE_STATES, OUTPOS_INVALID,
-    PATTERN_ID_INVALID, PATTERN_LEN_INVALID, STATE_IDX_INVALID,
+    DoubleArrayAhoCorasick, Output, State, FAIL_INVALID, OUTPOS_INVALID, PATTERN_LEN_INVALID,
 };
+
+// The length of each double-array block.
+const BLOCK_LEN: usize = 256;
+// The number of last blocks to be searched in `DoubleArrayAhoCorasickBuilder::find_base`.
+const FREE_BLOCKS: usize = 16;
+// The number of last states (or elements) to be searched in `DoubleArrayAhoCorasickBuilder::find_base`.
+const FREE_STATES: usize = BLOCK_LEN * FREE_BLOCKS;
+// The maximum state index used as an invalid value.
+const STATE_IDX_INVALID: u32 = std::u32::MAX;
+// The maximum ID of a pattern used as an invalid value.
+const PATTERN_ID_INVALID: u32 = std::u32::MAX;
 
 struct SparseTrie {
     nodes: Vec<Vec<(u8, usize)>>,

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -15,7 +15,7 @@ const STATE_IDX_INVALID: u32 = std::u32::MAX;
 // The maximum ID of a pattern used as an invalid value.
 const PATTERN_ID_INVALID: u32 = std::u32::MAX;
 // The maximum FAIL value.
-const FAIL_MAX: usize = std::u32::MAX as usize >> 8;
+const FAIL_MAX: usize = 0x00ffffff;
 
 struct SparseTrie {
     nodes: Vec<Vec<(u8, usize)>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,8 +34,6 @@ use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 pub use builder::DoubleArrayAhoCorasickBuilder;
 use errors::DaachorseError;
 
-// The maximum ID of a pattern used as an invalid value.
-pub(crate) const PATTERN_ID_INVALID: u32 = std::u32::MAX;
 // The maximum length of a pattern used as an invalid value.
 pub(crate) const PATTERN_LEN_INVALID: u32 = std::u32::MAX >> 1;
 // The maximum BASE value used as an invalid value.
@@ -44,14 +42,6 @@ pub(crate) const BASE_INVALID: u32 = std::u32::MAX;
 pub(crate) const FAIL_INVALID: u32 = std::u32::MAX >> 8;
 // The maximum output position value used as an invalid value.
 pub(crate) const OUTPOS_INVALID: u32 = std::u32::MAX;
-// The maximum state index used as an invalid value.
-pub(crate) const STATE_IDX_INVALID: u32 = std::u32::MAX;
-// The length of each double-array block.
-pub(crate) const BLOCK_LEN: usize = 256;
-// The number of last blocks to be searched in `DoubleArrayAhoCorasickBuilder::find_base`.
-pub(crate) const FREE_BLOCKS: usize = 16;
-// The number of last states (or elements) to be searched in `DoubleArrayAhoCorasickBuilder::find_base`.
-pub(crate) const FREE_STATES: usize = BLOCK_LEN * FREE_BLOCKS;
 
 #[derive(Clone, Copy)]
 struct State {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,8 +38,6 @@ use errors::DaachorseError;
 pub(crate) const PATTERN_LEN_INVALID: u32 = std::u32::MAX >> 1;
 // The maximum BASE value used as an invalid value.
 pub(crate) const BASE_INVALID: u32 = std::u32::MAX;
-// The maximum FAIL value used as an invalid value.
-pub(crate) const FAIL_INVALID: u32 = std::u32::MAX >> 8;
 // The maximum output position value used as an invalid value.
 pub(crate) const OUTPOS_INVALID: u32 = std::u32::MAX;
 
@@ -54,7 +52,7 @@ impl Default for State {
     fn default() -> Self {
         Self {
             base: BASE_INVALID,
-            fach: FAIL_INVALID << 8,
+            fach: 0,
             output_pos: OUTPOS_INVALID,
         }
     }


### PR DESCRIPTION
I moved constant parameters used only in `builder.rs` to the file. And, `FAIL_INVALID` is replaced into `FAIL_MAX` because a default fail value can be set to zero and the constant parameter will be used only for indicating the maximum possible value. 